### PR TITLE
Compilecheck for mistake

### DIFF
--- a/sample/model_bar.go
+++ b/sample/model_bar.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	// Sheet definition
 	_Bar_sheetName        = "bars"
 	_Bar_column_UserID    = 0 // A
 	_Bar_column_Datetime  = 1 // B
@@ -24,7 +25,8 @@ const (
 	_Bar_column_UpdatedAt = 4 // E
 	_Bar_column_DeletedAt = 5 // F
 
-	_Bar_Parent_User         = 0
+	// Parent children relation for compile check
+	_Bar_parent_User         = 0
 	_Bar_numOfChildren       = 0
 	_Bar_numOfDirectChildren = 0
 )
@@ -35,6 +37,12 @@ var (
 	_Bar_rowNoMap = map[int]map[sheetdb.Datetime]int{}  // map[userID][datetime]rowNo
 	_Bar_maxRowNo = 0
 )
+
+func _() {
+	// An "undeclared name" compiler error signifies that parent-children option conflicts between models.
+	// Make sure that the parent-children options are correct for all relevant models and try again.
+	_ = _User_child_Bar
+}
 
 func init() {
 	sheetdb.SetModel("default", "Bar", _Bar_sheetName, _Bar_load)

--- a/sample/model_bar.go
+++ b/sample/model_bar.go
@@ -23,6 +23,10 @@ const (
 	_Bar_column_Note      = 3 // D
 	_Bar_column_UpdatedAt = 4 // E
 	_Bar_column_DeletedAt = 5 // F
+
+	_Bar_Parent_User         = 0
+	_Bar_numOfChildren       = 0
+	_Bar_numOfDirectChildren = 0
 )
 
 var (

--- a/sample/model_foo.go
+++ b/sample/model_foo.go
@@ -23,6 +23,11 @@ const (
 	_Foo_column_Note      = 3 // D
 	_Foo_column_UpdatedAt = 4 // E
 	_Foo_column_DeletedAt = 5 // F
+
+	_Foo_Parent_User          = 0
+	_Foo_DirectChild_FooChild = 0
+	_Foo_numOfChildren        = 1
+	_Foo_numOfDirectChildren  = 1
 )
 
 var (

--- a/sample/model_foo.go
+++ b/sample/model_foo.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	// Sheet definition
 	_Foo_sheetName        = "foos"
 	_Foo_column_UserID    = 0 // A
 	_Foo_column_FooID     = 1 // B
@@ -24,10 +25,11 @@ const (
 	_Foo_column_UpdatedAt = 4 // E
 	_Foo_column_DeletedAt = 5 // F
 
-	_Foo_Parent_User          = 0
-	_Foo_DirectChild_FooChild = 0
-	_Foo_numOfChildren        = 1
-	_Foo_numOfDirectChildren  = 1
+	// Parent children relation for compile check
+	_Foo_parent_User         = 0
+	_Foo_child_FooChild      = 0
+	_Foo_numOfChildren       = 1
+	_Foo_numOfDirectChildren = 1
 )
 
 var (
@@ -36,6 +38,18 @@ var (
 	_Foo_rowNoMap = map[int]map[int]int{}  // map[userID][fooID]rowNo
 	_Foo_maxRowNo = 0
 )
+
+func _() {
+	// An "undeclared name" compiler error signifies that parent-children option conflicts between models.
+	// Make sure that the parent-children options are correct for all relevant models and try again.
+	_ = _User_child_Foo
+	_ = _FooChild_parent_Foo
+	// An "invalid array index" compiler error signifies that the children option is incorrect.
+	// Make sure that all child models are specified, including not only the direct child model
+	// but also the grandchild model, and try again.
+	var x [1]struct{}
+	_ = x[_Foo_numOfChildren-_Foo_numOfDirectChildren-_FooChild_numOfChildren]
+}
 
 func init() {
 	sheetdb.SetModel("default", "Foo", _Foo_sheetName, _Foo_load)

--- a/sample/model_foochild.go
+++ b/sample/model_foochild.go
@@ -23,6 +23,8 @@ const (
 	_FooChild_column_Value     = 3 // D
 	_FooChild_column_UpdatedAt = 4 // E
 	_FooChild_column_DeletedAt = 5 // F
+
+	_FooChild_numOfChildren = 0
 )
 
 var (

--- a/sample/model_foochild.go
+++ b/sample/model_foochild.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	// Sheet definition
 	_FooChild_sheetName        = "fooChildren"
 	_FooChild_column_UserID    = 0 // A
 	_FooChild_column_FooID     = 1 // B
@@ -24,7 +25,10 @@ const (
 	_FooChild_column_UpdatedAt = 4 // E
 	_FooChild_column_DeletedAt = 5 // F
 
-	_FooChild_numOfChildren = 0
+	// Parent children relation for compile check
+	_FooChild_parent_Foo          = 0
+	_FooChild_numOfChildren       = 0
+	_FooChild_numOfDirectChildren = 0
 )
 
 var (
@@ -33,6 +37,12 @@ var (
 	_FooChild_rowNoMap = map[int]map[int]map[int]int{}       // map[userID][fooID][childID]rowNo
 	_FooChild_maxRowNo = 0
 )
+
+func _() {
+	// An "undeclared name" compiler error signifies that parent-children option conflicts between models.
+	// Make sure that the parent-children options are correct for all relevant models and try again.
+	_ = _Foo_child_FooChild
+}
 
 func init() {
 	sheetdb.SetModel("default", "FooChild", _FooChild_sheetName, _FooChild_load)

--- a/sample/model_typetest.go
+++ b/sample/model_typetest.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	// Sheet definition
 	_TypeTest_sheetName             = "typeTests"
 	_TypeTest_column_ID             = 0  // A
 	_TypeTest_column_StringValue    = 1  // B

--- a/sample/model_user.go
+++ b/sample/model_user.go
@@ -16,6 +16,7 @@ import (
 )
 
 const (
+	// Sheet definition
 	_User_sheetName        = "users"
 	_User_column_UserID    = 0 // A
 	_User_column_Name      = 1 // B
@@ -25,8 +26,9 @@ const (
 	_User_column_UpdatedAt = 5 // F
 	_User_column_DeletedAt = 6 // G
 
-	_User_Child_Foo           = 0
-	_User_Child_Bar           = 0
+	// Parent children relation for compile check
+	_User_child_Foo           = 0
+	_User_child_Bar           = 0
 	_User_numOfChildren       = 3
 	_User_numOfDirectChildren = 2
 )
@@ -40,10 +42,13 @@ var (
 )
 
 func _() {
-	_ = _Foo_Parent_User
-	_ = _Bar_Parent_User
-	// An "invalid array index" compiler error signifies that the constant values have changed.
-	// Re-run the stringer command to generate them again.
+	// An "undeclared name" compiler error signifies that parent-children option conflicts between models.
+	// Make sure that the parent-children options are correct for all relevant models and try again.
+	_ = _Foo_parent_User
+	_ = _Bar_parent_User
+	// An "invalid array index" compiler error signifies that the children option is incorrect.
+	// Make sure that all child models are specified, including not only the direct child model
+	// but also the grandchild model, and try again.
 	var x [1]struct{}
 	_ = x[_User_numOfChildren-_User_numOfDirectChildren-_Foo_numOfChildren-_Bar_numOfChildren]
 }

--- a/sample/model_user.go
+++ b/sample/model_user.go
@@ -24,6 +24,11 @@ const (
 	_User_column_Birthday  = 4 // E
 	_User_column_UpdatedAt = 5 // F
 	_User_column_DeletedAt = 6 // G
+
+	_User_Child_Foo           = 0
+	_User_Child_Bar           = 0
+	_User_numOfChildren       = 3
+	_User_numOfDirectChildren = 2
 )
 
 var (
@@ -33,6 +38,15 @@ var (
 	_User_maxRowNo        = 0
 	_User_Email_uniqueSet = map[string]struct{}{}
 )
+
+func _() {
+	_ = _Foo_Parent_User
+	_ = _Bar_Parent_User
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[_User_numOfChildren-_User_numOfDirectChildren-_Foo_numOfChildren-_Bar_numOfChildren]
+}
 
 func init() {
 	sheetdb.SetModel("default", "User", _User_sheetName, _User_load)

--- a/tools/sheetdb-modeler/generate.go
+++ b/tools/sheetdb-modeler/generate.go
@@ -33,6 +33,7 @@ type model struct {
 	ChildrenNamePlurals      []string
 	ChildrenNameLowers       []string
 	ChildrenNameLowerPlurals []string
+	DirectChildrenNames      []string
 }
 
 type option struct {

--- a/tools/sheetdb-modeler/generate.go
+++ b/tools/sheetdb-modeler/generate.go
@@ -91,6 +91,11 @@ func (g *Generator) generate(typeName, parentName, childrenNames, clientName, mo
 		s.Model.ChildrenNameLowers = append(s.Model.ChildrenNameLowers, gocase.To(strcase.ToLowerCamel(gocase.Revert(c))))
 		s.Model.ChildrenNameLowerPlurals = append(s.Model.ChildrenNameLowerPlurals, gocase.To(inflection.Plural(strcase.ToLowerCamel(gocase.Revert(c)))))
 	}
+	for _, c := range s.ChildrenModels {
+		if len(c.PkNames) == len(s.Model.PkNames)+1 {
+			s.Model.DirectChildrenNames = append(s.Model.DirectChildrenNames, c.Name)
+		}
+	}
 
 	opt := option{
 		ClientName:   clientName,


### PR DESCRIPTION
自動生成はモデルごとに実行されるため、実行のタイミングで、親子関係の指定ミスをチェックすることができない。そのため、下記のチェックについてはcompileエラーを発生させることで対応する。

* 親/子モデル間での指定矛盾（モデルAがモデルBを子供と指定した場合、モデルBがモデルAを親と指定しなければエラー）
* 孫モデルを含め、子モデルを全て列挙しなければエラー（CascadeDeleteのため、孫モデルも指定する必要がある）

compileエラーの実装に関しては、`stringer`を参考とした。